### PR TITLE
Refactor the config to walk attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ A service will be created as `hab-depot`.
 
 ## Attributes
 
+There are several attributes used to render the configuration files used for the api and sessionsrv services. They live under `node['depot']['oauth']` and `node['depot']['user_toml']`.
+
 |*name*|*default*|*description*|
 |------|---------|-------------|
 |`node['depot']['oauth']['client_id']`|`nil`| Github Client ID for OAuth |
 |`node['depot']['oauth']['client_secret']`|`nil`| Github Client Secret for OAuth |
-|`node['depot']['fqdn']`|`node['fqdn']` or `node.name`|This will be set to the `node['fqdn']` attribute, and fall back to the `node.name`. |
+|`node['depot']['user_toml']`|See `./attributes/default.rb`| Specify each key in the hash rendered in the TOML file with its value |
+|`node['depot']['user_toml']['app_url']`|`'http://FQDN/v1'`| FQDN defaults to `node['fqdn']`, falling back to `node.name` |
 
 If the `client_id` and `client_secret` are not set, users will not be able to sign in, create origins, or upload packages to the Depot. Create an OAuth application on Github first, and then use the values for these attributes.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,16 @@
 # register an OAuth application for GitHub
-default['depot']['oauth']['client_id'] = nil
-default['depot']['oauth']['client_secret'] = nil
+default['depot']['oauth'].tap do |oauth|
+  oauth['client_id'] = nil
+  oauth['client_secret'] = nil
+end
 
-# fqdn that can be resolved, ie depot.example.com
-default['depot']['fqdn'] = node['fqdn'] || node.name
+default['depot']['user_toml'].tap do |user_toml|
+  user_toml['app_url']         = "http://#{node['fqdn'] || node.name}/v1"
+  user_toml['community_url']   = 'https://www.habitat.sh/community'
+  user_toml['docs_url']        = 'https://www.habitat.sh/docs'
+  user_toml['environment']     = 'private'
+  user_toml['friends_only']    = false
+  user_toml['source_code_url'] = 'https://github.com/habitat-sh/habitat'
+  user_toml['www_url']         = 'https://www.habitat.sh'
+  user_toml['tutorials_url']   = 'https://www.habitat.sh/tutorials'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,9 +53,8 @@ end
 template '/hab/svc/hab-builder-api/user.toml' do
   source 'hab-builder-api-user.toml.erb'
   variables(
-    oauth_app_client_id: node['depot']['oauth']['client_id'],
-    oauth_app_client_secret: node['depot']['oauth']['client_secret'],
-    fqdn: node['depot']['fqdn']
+    oauth: node['depot']['oauth'],
+    user_toml: node['depot']['user_toml']
   )
   sensitive true
 end
@@ -67,10 +66,7 @@ end
 
 template '/hab/svc/hab-builder-sessionsrv/user.toml' do
   source 'hab-builder-sessionsrv-user.toml.erb'
-  variables(
-    oauth_app_client_id: node['depot']['oauth']['client_id'],
-    oauth_app_client_secret: node['depot']['oauth']['client_secret']
-  )
+  variables oauth: node['depot']['oauth']
   sensitive true
 end
 

--- a/templates/hab-builder-api-user.toml.erb
+++ b/templates/hab-builder-api-user.toml.erb
@@ -1,13 +1,9 @@
 [github]
-client_id       = "<%= @oauth_app_client_id %>"
-client_secret   = "<%= @oauth_app_client_secret %>"
+<% @oauth.each do |cfg, val| -%>
+<%= cfg.ljust(@oauth.keys.max_by{|i|i.length}.length) %> = <%= val.inspect %>
+<% end -%>
 
 [ui]
-app_url         = "http://<%= @fqdn %>/v1"
-community_url   = "https://www.habitat.sh/community"
-docs_url        = "https://www.habitat.sh/docs"
-environment     = "private"
-friends_only    = false
-source_code_url = "https://github.com/habitat-sh/habitat"
-tutorials_url   = "https://www.habitat.sh/tutorials"
-www_url         = "https://www.habitat.sh"
+<% @user_toml.each do |cfg, val| -%>
+<%= cfg.ljust(@user_toml.keys.max_by{|i|i.length}.length) %> = <%= val.inspect %>
+<% end -%>

--- a/templates/hab-builder-sessionsrv-user.toml.erb
+++ b/templates/hab-builder-sessionsrv-user.toml.erb
@@ -1,3 +1,4 @@
 [github]
-client_id       = "<%= @oauth_app_client_id %>"
-client_secret   = "<%= @oauth_app_client_secret %>"
+<% @oauth.each do |cfg, val| -%>
+<%= cfg.ljust(@oauth.keys.max_by{|i|i.length}.length) %> = <%= val.inspect %>
+<% end -%>


### PR DESCRIPTION
The configuration is somewhat inflexible. It allows only three things
to be set - the oauth id and secret, and the fqdn. It doesn't allow
the user to specify the HTTP vs HTTPS scheme of the `app_url`, or
customize any of the other URLs used in the API configuration. While
it's unknown whether those will affect any behavior, it is relatively
simple to adapt the configuration to iterate over the configuration
values as a hash and render the template.

Signed-off-by: Joshua Timberman <joshua@chef.io>